### PR TITLE
infra: setup local docker environment with pgvector

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  db:
+    image: pgvector/pgvector:pg16
+    container_name: tt2_postgres
+    restart: always
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+      POSTGRES_DB: security_db
+    ports:
+      - "5432:5432"
+    volumes:
+      # Inyecta tu archivo SQL dentro de la carpeta mágica de inicialización de Postgres
+      - ./backend/database/schema.sql:/docker-entrypoint-initdb.d/init.sql


### PR DESCRIPTION
Closes #5

## Description
This PR introduces the local containerized infrastructure for the security system's database. It utilizes `docker-compose` to spin up a PostgreSQL 16 instance with the `pgvector` extension, ensuring a reproducible environment across all developer machines.

## Architectural Decisions
- **Isolation:** The database runs in a WSL2-backed Docker container to avoid polluting the host OS and to standardize the development environment.
- **Auto-initialization:** Configured a volume mount to automatically execute the `schema.sql` DDL script on the initial container boot.
- **Port Mapping:** Exposed port `5432` to the host to allow the future Python/FastAPI backend to connect seamlessly.

## Verification
- [x] `docker-compose.yml` successfully tested locally.
- [x] Volume mapping correctly injects and executes the DDL schema.
- [x] Database starts and accepts external connections on port `5432`.