### PR TITLE
infra: configure MinIO object storage in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,7 @@
 services:
+  # ==========================================
+  # 1. DATABASE (Analytical Brain)
+  # ==========================================
   db:
     image: pgvector/pgvector:pg16
     container_name: tt2_postgres
@@ -10,5 +13,27 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      # Inyecta tu archivo SQL dentro de la carpeta mágica de inicialización de Postgres
       - ./backend/database/schema.sql:/docker-entrypoint-initdb.d/init.sql
+
+  # ==========================================
+  # 2. OBJECT STORAGE (Evidence Vault)
+  # ==========================================
+  minio:
+    image: minio/minio:latest
+    container_name: tt2_minio
+    restart: always
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: password123  # In production, this should be injected via a .env file
+    ports:
+      - "9000:9000"     # S3 API port (For Python backend communication)
+      - "9001:9001"     # Web Console port (For manual administration)
+    volumes:
+      - minio_data:/data
+    command: server /data --console-address ":9001"
+
+# ==========================================
+# PERSISTENT VOLUMES
+# ==========================================
+volumes:
+  minio_data:


### PR DESCRIPTION
## Summary
This PR introduces the MinIO object storage service to our local Docker infrastructure. This serves as the foundational S3-compatible vault for storing video evidence generated by the AI pipelines, preventing PostgreSQL database bloat.

## Related Issue
Closes #8

## Type of Change
- [x] Bug fix
- [x] New feature / Infrastructure
- [ ] Breaking change

## How Has This Been Tested?
- [x] Manual Integration Test: Executed `docker compose up -d` and successfully authenticated into the MinIO web console at `localhost:9001`.
- [ ] Automated Test

## Checklist
- [x] My code follows the atomic principles (one task per PR).
- [x] I have performed a self-review of my code.
- [x] Commits follow the Conventional Commits standard.