### PR TITLE
fix(infra): restore 5433 port mapping accidentally overwritten in pre…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: admin
       POSTGRES_DB: security_db
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - ./backend/database/schema.sql:/docker-entrypoint-initdb.d/init.sql
 


### PR DESCRIPTION
…vious merge

The previous PR squashed a commit that accidentally reverted the local Postgres port back to 5432. This hotfix restores the intended 5433 mapping to prevent local dev collisions.