### PR TITLE
Feat/37 camera enrollment

### DIFF
--- a/backend/src/modules/weapons/inference.py
+++ b/backend/src/modules/weapons/inference.py
@@ -160,13 +160,40 @@ def start_weapon_model() -> None:
                 continue
 
             t0 = time.time()
-            results = model(frame, verbose=False, conf=CONFIDENCE_THRESHOLD)
+            # Track instead of plain inference. ByteTrack assigns a stable
+            # integer ID to each detection across frames, so a flickering
+            # confidence on the same physical object is observable as a single
+            # track in the orchestrator (which then applies the debouncer).
+            # `persist=True` keeps the tracker state between calls; otherwise
+            # IDs would reset every frame and tracking would be meaningless.
+            results = model.track(
+                frame,
+                verbose=False,
+                conf=CONFIDENCE_THRESHOLD,
+                tracker="bytetrack.yaml",
+                persist=True,
+            )
             infer_ms = (time.time() - t0) * 1000.0
 
             detections_payload = []
 
             for result in results:
-                for box in result.boxes:
+                if result.boxes is None:
+                    continue
+
+                # `result.boxes.id` is None when the tracker has not yet
+                # confirmed a track (typical for the first 1-2 frames of an
+                # object's life). We surface those detections with track_id
+                # = None so the orchestrator can still log them, but the
+                # debouncer keys on track_id and will simply not increment
+                # any counter for them.
+                track_ids = (
+                    result.boxes.id.int().cpu().tolist()
+                    if result.boxes.id is not None
+                    else [None] * len(result.boxes)
+                )
+
+                for box, track_id in zip(result.boxes, track_ids):
                     cls_id = int(box.cls[0])
                     cls_name = model.names[cls_id]
 
@@ -180,6 +207,7 @@ def start_weapon_model() -> None:
                         "class": cls_name,
                         "confidence": round(confidence, 4),
                         "bbox": bbox,
+                        "track_id": track_id,
                     })
 
             # Only publish on positive detections. Empty publishes would clear
@@ -204,8 +232,10 @@ def start_weapon_model() -> None:
                 result_sender.send_json(payload)
 
                 for d in detections_payload:
+                    tid = d.get("track_id")
+                    tid_str = f"id={tid}" if tid is not None else "id=?"
                     logger.warning(
-                        f"[WEAPON DETECTED] {d['class']} "
+                        f"[WEAPON DETECTED] {d['class']} {tid_str} "
                         f"conf={d['confidence']*100:.1f}% "
                         f"infer={infer_ms:.0f}ms"
                     )
@@ -219,4 +249,3 @@ def start_weapon_model() -> None:
 
         except Exception as e:
             logger.debug(f"Inference cycle error: {e}")
-

--- a/backend/src/orchestrator/rules.py
+++ b/backend/src/orchestrator/rules.py
@@ -37,6 +37,26 @@ ANNOTATED_SUB_PORT = os.getenv("ANNOTATED_PUB_PORT", "tcp://127.0.0.1:5557")
 # events before evaluating compound rules.
 COMPOUND_EVENT_WINDOW_SECONDS = float(os.getenv("COMPOUND_EVENT_WINDOW_SECONDS", "2.0"))
 
+# --- Weapon debouncer parameters ---
+# A single high-confidence frame is not enough to fire a weapon alert. With
+# ByteTrack assigning a stable id per physical object, we require a track to
+# accumulate `WEAPON_DEBOUNCE_HITS` detections within `WEAPON_DEBOUNCE_WINDOW`
+# seconds before promoting it to a real incident. This kills isolated flicker
+# false positives without sacrificing latency on real threats: at 10 FPS, 5
+# hits is ~0.5s of sustained detection, well below human reaction time.
+#
+# `WEAPON_DEBOUNCE_MIN_AVG_CONF` is a second gate on the rolling average
+# confidence inside the window. Useful when the model produces sustained but
+# low-confidence detections (often a sign of an ambiguous object like a
+# phone or remote being mis-classified at low conf).
+WEAPON_DEBOUNCE_HITS = int(os.getenv("WEAPON_DEBOUNCE_HITS", "5"))
+WEAPON_DEBOUNCE_WINDOW = float(os.getenv("WEAPON_DEBOUNCE_WINDOW", "1.5"))
+WEAPON_DEBOUNCE_MIN_AVG_CONF = float(os.getenv("WEAPON_DEBOUNCE_MIN_AVG_CONF", "0.60"))
+# How long (seconds) to keep a track in the debouncer buffer with no new
+# hits before garbage-collecting it. Prevents the buffer from growing forever
+# when many short-lived tracks pass through.
+WEAPON_TRACK_TTL = float(os.getenv("WEAPON_TRACK_TTL", "5.0"))
+
 # Internal API endpoint for alert broadcasting. Kept env-driven so the
 # orchestrator and the FastAPI host can be deployed on different machines.
 ALERT_API_URL = os.getenv("ALERT_API_URL", "http://127.0.0.1:8000/api/alerts/")
@@ -99,6 +119,105 @@ class AnnotatedFrameBuffer:
 # module attribute (not a true global mutable) so the helper functions
 # (_save_evidence, etc.) can access it without threading every signature.
 _frame_buffer: Optional[AnnotatedFrameBuffer] = None
+
+
+class WeaponDebouncer:
+    """
+    Per-track debouncer for weapon detections.
+
+    A single high-confidence frame is not sufficient to promote a detection
+    into an incident: model output flickers, and the false-positive curve at
+    high confidence is non-zero (see F1-Confidence analysis). Combined with
+    the inference worker's switch from `model()` to `model.track()`, every
+    detection now carries a stable `track_id` issued by ByteTrack — which
+    means we can reason about the same physical object across frames.
+
+    A track must accumulate at least `hits` detections within `window`
+    seconds AND maintain a rolling average confidence ≥ `min_avg_conf`
+    before this debouncer returns True. Once a track has been confirmed,
+    it is flagged so subsequent frames of the same track do not re-trigger
+    the (expensive) incident pipeline — that responsibility belongs to the
+    cooldown table downstream.
+
+    Tracks that go silent for more than `ttl` seconds are evicted on the
+    next access. The expected steady-state size is O(active threats per
+    camera), which in residential CCTV is ~0-2.
+    """
+
+    def __init__(
+        self,
+        hits: int,
+        window_seconds: float,
+        min_avg_conf: float,
+        ttl_seconds: float,
+    ):
+        self._hits = hits
+        self._window = window_seconds
+        self._min_avg_conf = min_avg_conf
+        self._ttl = ttl_seconds
+        # key: (camera_id, track_id, class) -> {"events": [(t, conf), ...], "confirmed": bool}
+        # We key on class too because the same track_id flipping between
+        # 'knife' and 'pistol' should not borrow confirmations across classes
+        # (rare in practice but defensive).
+        self._tracks: Dict[tuple, Dict[str, Any]] = {}
+
+    def _gc(self, now: float) -> None:
+        """Evict tracks idle for longer than ttl."""
+        stale = [
+            key for key, state in self._tracks.items()
+            if not state["events"] or (now - state["events"][-1][0]) > self._ttl
+        ]
+        for key in stale:
+            del self._tracks[key]
+
+    def observe(
+        self,
+        camera_id: str,
+        track_id: Optional[int],
+        cls: str,
+        confidence: float,
+    ) -> bool:
+        """
+        Record one detection and return True iff this track has just been
+        confirmed as a real incident (transitions from unconfirmed to
+        confirmed). Subsequent calls on a confirmed track return False, so
+        the caller fires the incident exactly once per track lifetime.
+
+        track_id may be None during the first 1-2 frames of an object's
+        life (ByteTrack has not yet assigned an id). We treat those as
+        non-debounceable and never confirm them — the next frame, once the
+        tracker has stabilized, will start the counter.
+        """
+        if track_id is None:
+            return False
+
+        now = time.time()
+        # Periodic eviction. Cheap: a dozen tracks max in residential CCTV.
+        self._gc(now)
+
+        key = (camera_id, track_id, cls)
+        state = self._tracks.setdefault(key, {"events": [], "confirmed": False})
+
+        # Drop events outside the rolling window before appending the new one.
+        state["events"] = [(t, c) for (t, c) in state["events"] if (now - t) <= self._window]
+        state["events"].append((now, confidence))
+
+        if state["confirmed"]:
+            return False
+
+        if len(state["events"]) < self._hits:
+            return False
+
+        avg_conf = sum(c for _, c in state["events"]) / len(state["events"])
+        if avg_conf < self._min_avg_conf:
+            return False
+
+        state["confirmed"] = True
+        return True
+
+
+# Populated when start_orchestrator() runs, same pattern as _frame_buffer.
+_weapon_debouncer: Optional[WeaponDebouncer] = None
 
 
 PRIORITY_LOW = "LOW"
@@ -277,16 +396,34 @@ def _evaluate_weapon_event(db, event: Dict[str, Any]) -> Optional[Dict[str, Any]
     for detection in detections:
         weapon_class = detection.get("class", "unknown")
         confidence = detection.get("confidence", 0.0)
+        track_id = detection.get("track_id")
         conf_pct = confidence * 100
 
+        # The summary is populated for ALL detections (even unconfirmed ones),
+        # because the compound rule engine should still know a weapon was
+        # spotted in this window. Only the standalone WEAPON_DETECTED
+        # incident is gated by the debouncer.
         weapon_summary["weapon_detected"] = True
         weapon_summary["weapons"].append(weapon_class)
+
+        # Debouncer: only the first frame that promotes this track to
+        # 'confirmed' returns True. All other frames of the same track
+        # return False so we don't re-enter the incident pipeline.
+        confirmed = (
+            _weapon_debouncer is not None
+            and _weapon_debouncer.observe(camera_id, track_id, weapon_class, confidence)
+        )
+        if not confirmed:
+            continue
 
         if _check_cooldown(camera_id, "WEAPON_DETECTED"):
             incident = _create_incident(db, event, "WEAPON_DETECTED", PRIORITY_HIGH)
             _create_alert(db, incident.id, f"ARMA DETECTADA: {weapon_class} en {camera_id} ({timestamp}) - Confianza: {conf_pct:.1f}%")
             _save_evidence(incident.id, camera_id, frame_data)
-            logger.warning(f"[WEAPON ALERT] {weapon_class} detected at {timestamp} on {camera_id} (Confidence: {conf_pct:.1f}%)")
+            logger.warning(
+                f"[WEAPON ALERT] {weapon_class} (track={track_id}) confirmed at "
+                f"{timestamp} on {camera_id} (Confidence: {conf_pct:.1f}%)"
+            )
 
     return weapon_summary
 
@@ -388,8 +525,19 @@ def start_orchestrator() -> None:
     # event arrives, minimizing the cold-start window where _save_evidence
     # would have nothing to persist. The buffer is exposed via a module-level
     # name so the helper functions can reach it without signature changes.
-    global _frame_buffer
+    global _frame_buffer, _weapon_debouncer
     _frame_buffer = AnnotatedFrameBuffer(ANNOTATED_SUB_PORT)
+    _weapon_debouncer = WeaponDebouncer(
+        hits=WEAPON_DEBOUNCE_HITS,
+        window_seconds=WEAPON_DEBOUNCE_WINDOW,
+        min_avg_conf=WEAPON_DEBOUNCE_MIN_AVG_CONF,
+        ttl_seconds=WEAPON_TRACK_TTL,
+    )
+    logger.info(
+        f"Weapon debouncer online (hits={WEAPON_DEBOUNCE_HITS}, "
+        f"window={WEAPON_DEBOUNCE_WINDOW}s, "
+        f"min_avg_conf={WEAPON_DEBOUNCE_MIN_AVG_CONF})"
+    )
 
     context = zmq.Context()
     receiver = context.socket(zmq.PULL)
@@ -431,4 +579,3 @@ def start_orchestrator() -> None:
 
         except Exception as e:
             logger.error(f"Error processing event: {e}")
-

--- a/frontend/src/features/residents/components/Residents.tsx
+++ b/frontend/src/features/residents/components/Residents.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import {
   UserPlus,
   Loader2,
+  Camera,
 } from 'lucide-react';
 import {
   Card,
@@ -19,6 +20,12 @@ import { ErrorBanner, SuccessBanner } from '../../../components/ui/banner';
 
 import { ApiPerson } from '../../../types';
 import { apiFetch } from '../../../api/client';
+import WebcamFeed from './WebcamFeed';
+
+// Pose hints for the in-browser camera capture path. The backend treats the
+// three files as an unordered set; these labels are UI affordances only, to
+// nudge the operator into varying head angles for a richer master vector.
+const POSE_HINTS = ['Front', 'Left', 'Right'] as const;
 
 export function Residents({ query = '' }: { query?: string }) {
   const [persons, setPersons] = useState<ApiPerson[]>([]);
@@ -42,6 +49,16 @@ export function Residents({ query = '' }: { query?: string }) {
   const [enrolling, setEnrolling] = useState(false);
   const [enrollMsg, setEnrollMsg] = useState('');
   const [enrollError, setEnrollError] = useState('');
+
+  // Toggle between the legacy file-upload path and the in-browser camera
+  // capture path. Both produce the same File[] payload, so the submission
+  // pipeline downstream is unchanged.
+  const [captureMode, setCaptureMode] = useState<'upload' | 'camera'>('upload');
+
+  // Latest live frame from WebcamFeed. WebcamFeed paints its hidden canvas
+  // continuously; we keep a pointer here so captureFromCamera can snapshot
+  // the most recent frame synchronously on click.
+  const latestCanvasRef = useRef<HTMLCanvasElement | null>(null);
 
   const load = () => {
     setLoadError('');
@@ -107,6 +124,46 @@ export function Residents({ query = '' }: { query?: string }) {
     setEnrollSlots([null, null, null]);
   };
 
+  // WebcamFeed pushes its hidden canvas here on every painted frame. Storing
+  // the reference (not the pixel data) keeps this callback O(1) and stable
+  // across re-renders.
+  const handleFrame = useCallback((canvas: HTMLCanvasElement) => {
+    latestCanvasRef.current = canvas;
+  }, []);
+
+  // Snapshot the latest webcam frame into a JPEG File and drop it into the
+  // first empty slot. Quality 0.92 matches the backend evidence pipeline and
+  // is well above the threshold where ArcFace landmark extraction degrades.
+  const captureFromCamera = () => {
+    const canvas = latestCanvasRef.current;
+    if (!canvas) {
+      setEnrollError('Camera frame not ready yet. Wait a moment and try again.');
+      return;
+    }
+
+    const nextSlot = enrollSlots.findIndex((slot) => slot === null);
+    if (nextSlot === -1) return; // buffer saturated
+
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          setEnrollError('Failed to capture frame from camera.');
+          return;
+        }
+        const poseHint = POSE_HINTS[nextSlot].toLowerCase();
+        const file = new File(
+          [blob],
+          `enrollment_${poseHint}_${Date.now()}.jpg`,
+          { type: 'image/jpeg' }
+        );
+        setSlotFile(nextSlot, file);
+        setEnrollError('');
+      },
+      'image/jpeg',
+      0.92
+    );
+  };
+
   const enrollBiometrics = async (personId: string) => {
     const validFiles = enrollSlots.filter(Boolean) as File[];
     if (validFiles.length !== 3) {
@@ -156,6 +213,8 @@ export function Residents({ query = '' }: { query?: string }) {
   const isVisitor = form.person_type === 'VISITOR';
   const stagedCount = enrollSlots.filter(Boolean).length;
   const canFinalizeEnrollment = stagedCount === 3;
+  const nextSlotIndex = enrollSlots.findIndex((slot) => slot === null);
+  const bufferSaturated = nextSlotIndex === -1;
 
   return (
     <div className="space-y-4">
@@ -225,6 +284,68 @@ export function Residents({ query = '' }: { query?: string }) {
                             </Badge>
                           </div>
 
+                          {/* Capture mode toggle. Both modes populate the same
+                              File[] buffer downstream; only the source of the
+                              File objects differs. */}
+                          <div className="flex gap-2 text-xs">
+                            <button
+                              type="button"
+                              onClick={() => setCaptureMode('upload')}
+                              className={`px-3 py-1 rounded-md border transition ${
+                                captureMode === 'upload'
+                                  ? 'bg-slate-900 text-white border-slate-900'
+                                  : 'bg-white text-slate-700 hover:bg-slate-100'
+                              }`}
+                            >
+                              Upload files
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setCaptureMode('camera')}
+                              className={`px-3 py-1 rounded-md border transition ${
+                                captureMode === 'camera'
+                                  ? 'bg-slate-900 text-white border-slate-900'
+                                  : 'bg-white text-slate-700 hover:bg-slate-100'
+                              }`}
+                            >
+                              Capture from camera
+                            </button>
+                          </div>
+
+                          {/* Live webcam viewport (only mounted in camera mode
+                              so getUserMedia is not held open while uploading). */}
+                          {captureMode === 'camera' && (
+                            <div className="space-y-2">
+                              <div className="relative aspect-video rounded-lg overflow-hidden bg-black">
+                                <WebcamFeed
+                                  className="absolute inset-0"
+                                  onFrame={handleFrame}
+                                  fps={8}
+                                />
+                                {!bufferSaturated && (
+                                  <div className="absolute bottom-2 left-2 right-2 bg-black/60 text-white text-xs rounded px-2 py-1">
+                                    Next: <span className="font-semibold">{POSE_HINTS[nextSlotIndex]}</span>
+                                    {' · '}
+                                    {nextSlotIndex === 0 && 'Look straight at the camera'}
+                                    {nextSlotIndex === 1 && 'Turn your head slightly to the left'}
+                                    {nextSlotIndex === 2 && 'Turn your head slightly to the right'}
+                                  </div>
+                                )}
+                              </div>
+                              <Button
+                                size="sm"
+                                onClick={captureFromCamera}
+                                disabled={bufferSaturated || enrolling}
+                                className="gap-2"
+                              >
+                                <Camera className="h-3 w-3" />
+                                {bufferSaturated
+                                  ? 'Buffer full · retake a slot below'
+                                  : `Capture ${POSE_HINTS[nextSlotIndex]} frame`}
+                              </Button>
+                            </div>
+                          )}
+
                           <div className="grid gap-3">
                             {enrollSlots.map((file, slotIndex) => (
                               <div key={slotIndex} className="rounded-lg border p-3 bg-slate-50">
@@ -236,18 +357,23 @@ export function Residents({ query = '' }: { query?: string }) {
                                     </div>
                                   </div>
                                   <div className="flex gap-2">
-                                    <label className="inline-flex">
-                                      <input
-                                        type="file"
-                                        accept="image/jpeg,image/png"
-                                        className="hidden"
-                                        onChange={(e) => setSlotFile(slotIndex, e.target.files?.[0] ?? null)}
-                                        onClick={(e) => { (e.target as HTMLInputElement).value = ''; }}
-                                      />
-                                      <span className="inline-flex items-center rounded-md border px-3 py-1 text-xs cursor-pointer bg-white hover:bg-slate-100">
-                                        {file ? 'Retake' : 'Capture'}
-                                      </span>
-                                    </label>
+                                    {/* Upload-mode controls. Hidden in camera
+                                        mode so the operator isn't tempted to
+                                        mix sources within one session. */}
+                                    {captureMode === 'upload' && (
+                                      <label className="inline-flex">
+                                        <input
+                                          type="file"
+                                          accept="image/jpeg,image/png"
+                                          className="hidden"
+                                          onChange={(e) => setSlotFile(slotIndex, e.target.files?.[0] ?? null)}
+                                          onClick={(e) => { (e.target as HTMLInputElement).value = ''; }}
+                                        />
+                                        <span className="inline-flex items-center rounded-md border px-3 py-1 text-xs cursor-pointer bg-white hover:bg-slate-100">
+                                          {file ? 'Retake' : 'Capture'}
+                                        </span>
+                                      </label>
+                                    )}
                                     <Button
                                       size="sm"
                                       variant="ghost"
@@ -398,4 +524,3 @@ export function Residents({ query = '' }: { query?: string }) {
     </div>
   );
 }
-


### PR DESCRIPTION
Closes #37

## Summary

Adds an in-browser camera capture path to the biometric enrollment workflow, alongside the existing file-upload path. The operator can now toggle between uploading three image files or capturing three frames directly from the webcam.

## Changes

- `frontend/src/features/residents/components/Residents.tsx`:
  - New `captureMode` state toggling between `'upload'` (default, unchanged) and `'camera'`.
  - Camera mode mounts the existing `WebcamFeed` component and exposes a single Capture button that snapshots the latest live frame into the first empty slot.
  - Pose hints (Front / Left / Right) guide the operator through three head angles, producing a richer master vector.
  - Both modes feed the same `enrollSlots: File[]` buffer; submission pipeline and backend contract are unchanged.

## Architectural notes

- Camera and API communication remain separated: `WebcamFeed` handles `getUserMedia`, `Residents` handles the FormData payload.
- The webcam stream is only mounted while in camera mode, so `getUserMedia` is not held open during upload sessions.
- Exact-three invariant, slot-level delete/retake, and the disabled-until-3/3 finalize button are preserved from the existing implementation.

## Smoke test

- Upload mode: select 3 files → submit → enrollment succeeds.
- Camera mode: click "Capture Front" → "Capture Left" → "Capture Right" → submit → enrollment succeeds.
- Delete a slot in either mode → finalize button correctly disables.