### PR TITLE
feat(i18n): implement ES/EN language toggle with cookie persistence

### DIFF
--- a/frontend/src/i18n/LanguageContext.tsx
+++ b/frontend/src/i18n/LanguageContext.tsx
@@ -1,0 +1,66 @@
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  type ReactNode,
+} from 'react';
+import { es } from './locales/es';
+import { en } from './locales/en';
+import type { Dictionary } from './locales/es';
+
+export type Locale = 'es' | 'en';
+
+const COOKIE_KEY = 'uh_locale';
+const DICTIONARIES: Record<Locale, Dictionary> = { es, en };
+
+function getInitialLocale(): Locale {
+  // 1. Cookie persistida
+  const cookie = document.cookie
+    .split('; ')
+    .find((r) => r.startsWith(`${COOKIE_KEY}=`))
+    ?.split('=')[1];
+  if (cookie === 'es' || cookie === 'en') return cookie;
+
+  // 2. Accept-Language del navegador (fallback)
+  const lang = navigator.language.toLowerCase();
+  if (lang.startsWith('es')) return 'es';
+
+  // 3. Fallback a inglés (bedrock arquitectónico)
+  return 'en';
+}
+
+interface LanguageContextValue {
+  locale: Locale;
+  t: Dictionary;
+  setLocale: (l: Locale) => void;
+}
+
+const LanguageContext = createContext<LanguageContextValue | null>(null);
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocaleState] = useState<Locale>(getInitialLocale);
+
+  const setLocale = useCallback((l: Locale) => {
+    // Persiste en cookie (1 año)
+    document.cookie = `${COOKIE_KEY}=${l};path=/;max-age=31536000;SameSite=Lax`;
+    setLocaleState(l);
+  }, []);
+
+  return (
+    <LanguageContext.Provider value={{ locale, t: DICTIONARIES[locale], setLocale }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage(): LanguageContextValue {
+  const ctx = useContext(LanguageContext);
+  if (!ctx) throw new Error('useLanguage must be used inside <LanguageProvider>');
+  return ctx;
+}
+
+/** Helper para interpolación: t.alerts.unknownPersonDetected con {camera_id} */
+export function interpolate(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{(\w+)\}/g, (_, key) => vars[key] ?? `{${key}}`);
+}

--- a/frontend/src/i18n/LanguageToggle.tsx
+++ b/frontend/src/i18n/LanguageToggle.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Globe } from 'lucide-react';
+import { Button } from '../components/ui/button';
+import { useLanguage, type Locale } from './LanguageContext';
+
+const OPTIONS: { value: Locale; label: string }[] = [
+  { value: 'es', label: 'ES' },
+  { value: 'en', label: 'EN' },
+];
+
+export function LanguageToggle() {
+  const { locale, setLocale } = useLanguage();
+
+  return (
+    <div className="flex items-center gap-1">
+      <Globe className="h-4 w-4 text-slate-400" />
+      {OPTIONS.map((opt) => (
+        <Button
+          key={opt.value}
+          variant={locale === opt.value ? 'secondary' : 'ghost'}
+          size="sm"
+          className="h-7 px-2 text-xs font-semibold"
+          onClick={() => setLocale(opt.value)}
+          aria-pressed={locale === opt.value}
+        >
+          {opt.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1,0 +1,28 @@
+import type { Dictionary } from './es';
+
+export const en: Dictionary = {
+  nav: {
+    dashboard: 'Dashboard',
+    live: 'Live Monitoring',
+    alerts: 'Alerts',
+    incidents: 'Incidents',
+    residents: 'Residents',
+    access: 'Access Control',
+    settings: 'Settings',
+    navigation: 'Navigation',
+    sections: 'System Sections',
+  },
+  header: {
+    title: 'UH Security · Panel',
+    subtitle: 'Real-time monitoring · TT2',
+    notifications: 'Notifications',
+    searchPlaceholder: 'Search alerts, incidents or persons',
+  },
+  ws: {
+    connected: 'Backend connected in real time',
+    disconnected: 'No real-time backend connection available',
+  },
+  alerts: {
+    unknownPersonDetected: 'Unknown person detected at {camera_id}',
+  },
+};

--- a/frontend/src/i18n/locales/es.ts
+++ b/frontend/src/i18n/locales/es.ts
@@ -1,0 +1,28 @@
+export const es = {
+  nav: {
+    dashboard: 'Dashboard',
+    live: 'Monitoreo en vivo',
+    alerts: 'Alertas',
+    incidents: 'Incidentes',
+    residents: 'Residentes',
+    access: 'Control de Acceso',
+    settings: 'Configuración',
+    navigation: 'Navegación',
+    sections: 'Secciones del sistema',
+  },
+  header: {
+    title: 'Seguridad UH · Panel',
+    subtitle: 'Monitoreo en tiempo real · TT2',
+    notifications: 'Notificaciones',
+    searchPlaceholder: 'Buscar alertas, incidentes o personas',
+  },
+  ws: {
+    connected: 'Backend conectado en tiempo real',
+    disconnected: 'Sin conexión al backend en tiempo real',
+  },
+  alerts: {
+    unknownPersonDetected: 'Persona desconocida detectada en {camera_id}',
+  },
+} as const;
+
+export type Dictionary = typeof es;

--- a/frontend/src/layouts/SidebarLayout.tsx
+++ b/frontend/src/layouts/SidebarLayout.tsx
@@ -1,68 +1,54 @@
 import React from 'react';
 import {
-  AlertTriangle,
-  Bell,
-  Camera,
-  DoorOpen,
-  Gauge,
-  ListChecks,
-  Settings,
-  Siren,
-  Users,
-  Search,
+  AlertTriangle, Bell, Camera, DoorOpen, Gauge,
+  ListChecks, Settings, Siren, Users, Search,
 } from 'lucide-react';
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
+  Card, CardContent, CardDescription, CardHeader, CardTitle,
 } from '../components/ui/card';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
 import { AlertCounts } from '../types';
+import { useLanguage } from '../i18n/LanguageContext';
+import { LanguageToggle } from '../i18n/LanguageToggle';
 
 export type TabId =
-  | 'dashboard'
-  | 'live'
-  | 'alerts'
-  | 'incidents'
-  | 'residents'
-  | 'access'
-  | 'settings';
+  | 'dashboard' | 'live' | 'alerts' | 'incidents'
+  | 'residents' | 'access' | 'settings';
 
 function Header({
-  unreadCount,
-  searchQuery,
-  onSearchChange,
-  onOpenAlerts,
+  unreadCount, searchQuery, onSearchChange, onOpenAlerts,
 }: {
   unreadCount: number;
   searchQuery: string;
   onSearchChange: (value: string) => void;
   onOpenAlerts: () => void;
 }) {
+  const { t } = useLanguage();
+
   return (
     <div className="flex flex-col gap-3 py-4 md:flex-row md:items-center md:justify-between">
       <div className="flex items-center gap-3">
         <Siren className="h-7 w-7" />
         <div>
-          <h1 className="text-xl font-semibold leading-none">Seguridad UH · Panel</h1>
-          <p className="text-sm text-slate-500">Monitoreo en tiempo real · TT2</p>
+          <h1 className="text-xl font-semibold leading-none">{t.header.title}</h1>
+          <p className="text-sm text-slate-500">{t.header.subtitle}</p>
         </div>
       </div>
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <LanguageToggle />
         <div className="relative min-w-[260px]">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
           <Input
             value={searchQuery}
             onChange={(e) => onSearchChange(e.target.value)}
-            placeholder="Buscar alertas, incidentes o personas"
+            placeholder={t.header.searchPlaceholder}
             className="pl-9"
           />
         </div>
         <Button onClick={onOpenAlerts} className="gap-2 relative">
-          <Bell className="h-4 w-4" />Notificaciones
+          <Bell className="h-4 w-4" />
+          {t.header.notifications}
           {unreadCount > 0 && (
             <span className="absolute -top-1 -right-1 bg-red-500 text-white text-[10px] rounded-full h-4 w-4 flex items-center justify-center">
               {unreadCount > 9 ? '9+' : unreadCount}
@@ -75,13 +61,7 @@ function Header({
 }
 
 export function SidebarLayout({
-  tab,
-  setTab,
-  searchQuery,
-  setSearchQuery,
-  alertCounts,
-  wsConnected,
-  children,
+  tab, setTab, searchQuery, setSearchQuery, alertCounts, wsConnected, children,
 }: {
   tab: TabId;
   setTab: (t: TabId) => void;
@@ -91,6 +71,18 @@ export function SidebarLayout({
   wsConnected: boolean;
   children: React.ReactNode;
 }) {
+  const { t } = useLanguage();
+
+  const NAV_ITEMS = [
+    { id: 'dashboard', icon: Gauge,         label: t.nav.dashboard },
+    { id: 'live',      icon: Camera,        label: t.nav.live },
+    { id: 'alerts',    icon: AlertTriangle, label: t.nav.alerts,    badge: alertCounts.unread },
+    { id: 'incidents', icon: ListChecks,    label: t.nav.incidents },
+    { id: 'residents', icon: Users,         label: t.nav.residents },
+    { id: 'access',    icon: DoorOpen,      label: t.nav.access },
+    { id: 'settings',  icon: Settings,      label: t.nav.settings },
+  ] as const;
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-white to-slate-50">
       <div className="max-w-7xl mx-auto p-4">
@@ -103,27 +95,19 @@ export function SidebarLayout({
 
         <div className="flex items-center gap-2 mb-3 text-xs text-slate-500">
           <div className={`h-2 w-2 rounded-full ${wsConnected ? 'bg-emerald-500' : 'bg-red-400'}`} />
-          {wsConnected ? 'Backend connected in real time' : 'No real-time backend connection available'}
+          {wsConnected ? t.ws.connected : t.ws.disconnected}
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-[240px_1fr] gap-4">
           <div className="hidden lg:block">
             <Card className="sticky top-4">
               <CardHeader>
-                <CardTitle className="text-base">Navegación</CardTitle>
-                <CardDescription>Secciones del sistema</CardDescription>
+                <CardTitle className="text-base">{t.nav.navigation}</CardTitle>
+                <CardDescription>{t.nav.sections}</CardDescription>
               </CardHeader>
               <CardContent className="space-y-2">
                 <nav className="grid gap-1">
-                  {[
-                    { id: 'dashboard', icon: Gauge, label: 'Dashboard' },
-                    { id: 'live', icon: Camera, label: 'Monitoreo en vivo' },
-                    { id: 'alerts', icon: AlertTriangle, label: 'Alertas', badge: alertCounts.unread },
-                    { id: 'incidents', icon: ListChecks, label: 'Incidentes' },
-                    { id: 'residents', icon: Users, label: 'Residentes' },
-                    { id: 'access', icon: DoorOpen, label: 'Control de Acceso' },
-                    { id: 'settings', icon: Settings, label: 'Configuración' },
-                  ].map((it) => (
+                  {NAV_ITEMS.map((it) => (
                     <Button
                       key={it.id}
                       variant={tab === it.id ? 'secondary' : 'ghost'}
@@ -132,7 +116,7 @@ export function SidebarLayout({
                     >
                       <it.icon className="h-4 w-4" />
                       {it.label}
-                      {it.badge && it.badge > 0 ? (
+                      {'badge' in it && it.badge && it.badge > 0 ? (
                         <span className="ml-auto bg-red-500 text-white text-[10px] rounded-full h-4 w-4 flex items-center justify-center">
                           {it.badge > 9 ? '9+' : it.badge}
                         </span>
@@ -150,4 +134,3 @@ export function SidebarLayout({
     </div>
   );
 }
-

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,13 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
-import './index.css'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+import { LanguageProvider } from './i18n/LanguageContext';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
-)
+    <LanguageProvider>
+      <App />
+    </LanguageProvider>
+  </React.StrictMode>,
+);


### PR DESCRIPTION
## Summary
Implements the i18n architecture described in the issue, adapted for the existing Vite + React 18 + TypeScript stack.

## Changes
- `src/i18n/locales/es.ts` — Spanish dictionary (source of truth for types)
- `src/i18n/locales/en.ts` — English dictionary, typed against `es.ts`
- `src/i18n/LanguageContext.tsx` — React Context with cookie persistence and `Accept-Language` detection
- `src/i18n/LanguageToggle.tsx` — ES/EN toggle component in the header
- `src/layouts/SidebarLayout.tsx` — Migrated all hardcoded strings to translation keys
- `src/main.tsx` — Wrapped app with `<LanguageProvider>`

## Definition of Done
- [x] Type safety: removing a key from `es.ts` throws a TS compiler error
- [x] Cookie persistence: language survives page reload
- [x] Accept-Language detection: first visit uses browser language
- [x] Deterministic fallback to EN for missing/unknown locales
- [x] Toggle visible in header, zero layout shift on switch
- [x] No existing functionality modified

Closes #83 